### PR TITLE
covid19 #199 お知らせのURLが絶対パスの場合の処理を追加

### DIFF
--- a/scraping_naraNews.py
+++ b/scraping_naraNews.py
@@ -45,7 +45,10 @@ def parse_pref_item(item):
     str = item.attrs['href']
     str = str.replace('#module', ',')
     elem = str.split(',')
-    url = NARA_PREF_BASE_URL + elem[0]
+    if elem[0].startswith('http'):
+        url = elem[0]
+    else:
+        url = NARA_PREF_BASE_URL + elem[0]
     print(date, url, text)
     return date, url, text
 
@@ -81,7 +84,9 @@ def parse_city_item(date, title):
     # タイトル 
     text = title.find('a').string
     # 相対 → 絶対
-    url = NARA_CITY_BASE_URL + title.find('a').get('href')
+    url = title.find('a').get('href')
+    if not url.startswith('http'):
+        url = NARA_CITY_BASE_URL + title.find('a').get('href')
     print(date, url, text)
     return date, url, text
 


### PR DESCRIPTION
covid19 #199 に対応するために, scraping_naraNews.pyを以下のように改良.
お知らせのパスが絶対パスか相対パスかの判断を行い, URLを生成する.
・絶対パス ⇒ そのままURLに
・相対パス ⇒ "http://www.pref.nara.jp/” を付加してURLに

